### PR TITLE
fix prices for ukraine currency

### DIFF
--- a/index.php
+++ b/index.php
@@ -17,7 +17,7 @@ $TR = preg_replace("/[^0-9\.]/", '', $TRobj->lowest_price);
 // UA
 $UAjson = file_get_contents('https://steamcommunity.com/market/priceoverview/?appid=440&currency=18&market_hash_name=Mann%20Co.%20Supply%20Crate%20Key');
 $UAobj = json_decode($UAjson);
-$UA = preg_replace("/[^0-9\.]/", '', $UAobj->lowest_price)/100; 
+$UA = preg_replace("/[^0-9\.]/", '', $UAobj->lowest_price); 
 // RU
 $RUjson = file_get_contents('https://steamcommunity.com/market/priceoverview/?appid=440&currency=5&market_hash_name=Mann%20Co.%20Supply%20Crate%20Key');
 $RUobj = json_decode($RUjson);

--- a/ticket/index.php
+++ b/ticket/index.php
@@ -17,7 +17,7 @@ $TR = preg_replace("/[^0-9\.]/", '', $TRobj->lowest_price);
 // UA
 $UAjson = file_get_contents('https://steamcommunity.com/market/priceoverview/?appid=440&currency=18&market_hash_name=Tour%20of%20Duty%20Ticket');
 $UAobj = json_decode($UAjson);
-$UA = preg_replace("/[^0-9\.]/", '', $UAobj->lowest_price)/100; 
+$UA = preg_replace("/[^0-9\.]/", '', $UAobj->lowest_price); 
 // RU
 $RUjson = file_get_contents('https://steamcommunity.com/market/priceoverview/?appid=440&currency=5&market_hash_name=Tour%20of%20Duty%20Ticket');
 $RUobj = json_decode($RUjson);


### PR DESCRIPTION
با توجه به عدم نمایش اعشار در مارکت استیم، برای قیمت ایتم های ریجن اوکراین، دیگر نیازی به تقسیم بر 100 کردن قیمت نیست

نمونه پاسخ api استیم برای قیمت کلید tf2:
```
{
  "success": true,
  "lowest_price": "95₴",
  "volume": "64,860",
  "median_price": "93,90₴"
}
``` 
